### PR TITLE
[setting] ci/cd 구축, 코드 리뷰어 자동지정 

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @sxunea @haeti-dev @jife-archive

--- a/.github/workflows/ace_build.yml
+++ b/.github/workflows/ace_build.yml
@@ -53,7 +53,7 @@ jobs:
         uses: rtCamp/action-slack-notify@v2
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-          SLACK_CHANNEL: '#client-actions' # 알림을 받을 Slack 채널
+          SLACK_CHANNEL: "#client-actions" # 알림을 받을 Slack 채널
           SLACK_MESSAGE: "✅ CI 빌드 성공! PR: #${{ github.event.pull_request.number }} - `${{ github.event.pull_request.title }}`"
 
       - name: Slack 알림 (빌드 실패)
@@ -61,6 +61,5 @@ jobs:
         uses: rtCamp/action-slack-notify@v2
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-          SLACK_CHANNEL: '#client-actions'
+          SLACK_CHANNEL: "#client-actions"
           SLACK_MESSAGE: "❌ CI 빌드 실패! PR: #${{ github.event.pull_request.number }} - `${{ github.event.pull_request.title }}`"
-          SLACK_COLOR: 'danger'

--- a/.github/workflows/ace_build.yml
+++ b/.github/workflows/ace_build.yml
@@ -33,7 +33,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-gradle-
 
-      - name: local.properties 설정
+      # - name: local.properties 설정
         # 프로젝트의 local.properties 파일에 필요한 환경 변수를 설정합니다. 이후, 서버가 배포되면 주석 해제하여 사용합니다.
         # run: |
         #   echo "BASE_URL=${{ secrets.BASE_URL }}" >> local.properties

--- a/.github/workflows/ace_build.yml
+++ b/.github/workflows/ace_build.yml
@@ -4,7 +4,7 @@ name: Ace Client CI
 # 워크플로우 트리거 설정
 on:
   pull_request:
-    # 어떤 브랜치에서 시작하여 어떤 브랜치를 향하든 모든 Pull Request에 대해 트리거.
+    # 어떤 브랜치에서 시작하여 어떤 브랜치를 향하든 모든 Pull Request에 대해 트리거
     types: [ opened, synchronize, reopened ]
 
 jobs:

--- a/.github/workflows/ace_build.yml
+++ b/.github/workflows/ace_build.yml
@@ -1,0 +1,66 @@
+# CI.yml
+name: Ace Client CI
+
+# 워크플로우 트리거 설정
+on:
+  pull_request:
+    # 어떤 브랜치에서 시작하여 어떤 브랜치를 향하든 모든 Pull Request에 대해 트리거
+    types: [ opened, synchronize, reopened ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    # PR의 경우, PR이 draft 상태가 아닐 때만 실행합니다.
+    if: github.event.pull_request.draft == false
+
+    steps:
+      - name: 코드 체크아웃
+        uses: actions/checkout@v4
+
+      - name: JDK 17 설정
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+
+      - name: Gradle 캐시 설정
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+
+      - name: local.properties 설정
+        # 프로젝트의 local.properties 파일에 필요한 환경 변수를 설정합니다. 이후, 서버가 배포되면 주석 해제하여 사용합니다.
+        # run: |
+        #   echo "BASE_URL=${{ secrets.BASE_URL }}" >> local.properties
+
+      - name: 디버그 APK 빌드
+        run: ./gradlew assembleDebug
+
+      - name: 빌드 결과 아티팩트 저장 (선택 사항)
+        uses: actions/upload-artifact@v4
+        with:
+          name: debug-apk
+          path: app/build/outputs/apk/debug/app-debug.apk
+
+      - name: Slack 알림 (빌드 성공)
+        # 빌드 성공 시 Slack으로 알림을 보냅니다.
+        if: success()
+        uses: rtCamp/action-slack-notify@v2
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          SLACK_CHANNEL: '#client-actions' # 알림을 받을 Slack 채널
+          SLACK_MESSAGE: "✅ CI 빌드 성공! PR: #${{ github.event.pull_request.number }} - `${{ github.event.pull_request.title }}`"
+
+      - name: Slack 알림 (빌드 실패)
+        if: failure()
+        uses: rtCamp/action-slack-notify@v2
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          SLACK_CHANNEL: '#client-actions'
+          SLACK_MESSAGE: "❌ CI 빌드 실패! PR: #${{ github.event.pull_request.number }} - `${{ github.event.pull_request.title }}`"
+          SLACK_COLOR: 'danger'

--- a/.github/workflows/ace_build.yml
+++ b/.github/workflows/ace_build.yml
@@ -33,7 +33,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-gradle-
 
-      # - name: local.properties 설정
+        # - name: local.properties 설정
         # 프로젝트의 local.properties 파일에 필요한 환경 변수를 설정합니다. 이후, 서버가 배포되면 주석 해제하여 사용합니다.
         # run: |
         #   echo "BASE_URL=${{ secrets.BASE_URL }}" >> local.properties
@@ -48,18 +48,23 @@ jobs:
           path: app/build/outputs/apk/debug/app-debug.apk
 
       - name: Slack 알림 (빌드 성공)
-        # 빌드 성공 시 Slack으로 알림을 보냅니다.
         if: success()
-        uses: rtCamp/action-slack-notify@v2
+        uses: 8398a7/action-slack@v3
+        with:
+          status: success
+          fields: workflow,job,commit,repo,author,took,ref
+          author_name: GitHub Actions
+          text: "✅ CI 빌드 성공! PR: #${{ github.event.pull_request.number }} - `${{ github.event.pull_request.title }}`" # 메시지 내용
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-          SLACK_CHANNEL: "#client-actions" # 알림을 받을 Slack 채널
-          SLACK_MESSAGE: "✅ CI 빌드 성공! PR: #${{ github.event.pull_request.number }} - `${{ github.event.pull_request.title }}`"
 
       - name: Slack 알림 (빌드 실패)
         if: failure()
-        uses: rtCamp/action-slack-notify@v2
+        uses: 8398a7/action-slack@v3
+        with:
+          status: failure
+          fields: workflow,job,commit,repo,author,took,ref
+          author_name: GitHub Actions
+          text: "❌ CI 빌드 실패! PR: #${{ github.event.pull_request.number }} - `${{ github.event.pull_request.title }}`"
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-          SLACK_CHANNEL: "#client-actions"
-          SLACK_MESSAGE: "❌ CI 빌드 실패! PR: #${{ github.event.pull_request.number }} - `${{ github.event.pull_request.title }}`"

--- a/.github/workflows/ace_build.yml
+++ b/.github/workflows/ace_build.yml
@@ -4,7 +4,7 @@ name: Ace Client CI
 # 워크플로우 트리거 설정
 on:
   pull_request:
-    # 어떤 브랜치에서 시작하여 어떤 브랜치를 향하든 모든 Pull Request에 대해 트리거
+    # 어떤 브랜치에서 시작하여 어떤 브랜치를 향하든 모든 Pull Request에 대해 트리거합니다.
     types: [ opened, synchronize, reopened ]
 
 jobs:

--- a/.github/workflows/ace_build.yml
+++ b/.github/workflows/ace_build.yml
@@ -4,7 +4,7 @@ name: Ace Client CI
 # 워크플로우 트리거 설정
 on:
   pull_request:
-    # 어떤 브랜치에서 시작하여 어떤 브랜치를 향하든 모든 Pull Request에 대해 트리거
+    # 어떤 브랜치에서 시작하여 어떤 브랜치를 향하든 모든 Pull Request에 대해 트리거.
     types: [ opened, synchronize, reopened ]
 
 jobs:

--- a/.github/workflows/ace_firebase_distribution.yml
+++ b/.github/workflows/ace_firebase_distribution.yml
@@ -1,0 +1,84 @@
+# CD-Firebase.yml - Firebase App Distribution 배포 워크플로우
+name: Firebase App Distribution CD
+
+# 워크플로우 트리거 설정
+#on:
+#  push:
+#    branches:
+#      - develop
+
+jobs:
+  firebase_distribution:
+    name: Firebase App Distribution
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: 코드 체크아웃
+        uses: actions/checkout@v4
+
+      - name: JDK 17 설정
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+
+      - name: Gradle 캐시 설정
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+
+#      - name: local.properties 설정
+#        run: |
+#          echo "base.url=\"${{ secrets.BASE_URL }}\"" >> local.properties
+
+      - name: google-services.json 설정
+        # Firebase 서비스에 필요한 google-services.json 파일을 Secrets에서 가져와 복원합니다.
+        run: |
+          echo "google-services.json 파일을 설정합니다..."
+          echo '${{ secrets.GOOGLE_SERVICES_JSON }}' > ./app/google-services.json
+          if [ -f ./app/google-services.json ]; then
+            echo "google-services.json이 ./app/google-services.json에 성공적으로 생성되었습니다."
+          else
+            echo "오류: ./app/google-services.json에서 google-services.json을 찾을 수 없습니다."
+            exit 1
+          fi
+        shell: bash
+
+      - name: gradlew 실행 권한 부여
+        # gradlew 스크립트에 실행 권한이 없으면 빌드가 실패할 수 있으므로 권한을 부여합니다.
+        run: chmod +x ./gradlew
+
+      - name: 릴리스 APK 빌드 (Firebase App Distribution용)
+        # Firebase App Distribution을 위해 릴리스 APK를 빌드합니다.
+        run: ./gradlew assembleRelease
+
+      - name: Firebase App Distribution 업로드
+        # 빌드된 릴리스 APK를 Firebase App Distribution으로 업로드합니다.
+        uses: wzieba/Firebase-App-Distribution-Github-Action@v1
+        with:
+          appId: ${{ secrets.FIREBASE_APP_ID }}
+          token: ${{ secrets.FIREBASE_TOKEN }}
+          group: 'testers' # Firebase 콘솔에서 설정된 테스터 그룹 이름 지정해야됩니다.
+          file: app/build/outputs/apk/release/app-release.apk
+
+      - name: Slack 알림 (Firebase 배포 성공)
+        if: success()
+        uses: rtCamp/action-slack-notify@v2
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          SLACK_CHANNEL: '#client-actions'
+          SLACK_MESSAGE: "🚀 Firebase App Distribution 배포 성공! 브랜치: `${{ github.ref_name }}` 커밋: `${{ github.sha }}`"
+
+      - name: Slack 알림 (Firebase 배포 실패)
+        if: failure()
+        uses: rtCamp/action-slack-notify@v2
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          SLACK_CHANNEL: '#client-actions'
+          SLACK_MESSAGE: "🚨 Firebase App Distribution 배포 실패! 브랜치: `${{ github.ref_name }}` 커밋: `${{ github.sha }}`"
+          SLACK_COLOR: 'danger'

--- a/.github/workflows/ace_firebase_distribution.yml
+++ b/.github/workflows/ace_firebase_distribution.yml
@@ -66,19 +66,24 @@ jobs:
           group: 'testers' # Firebase 콘솔에서 설정된 테스터 그룹 이름 지정해야됩니다.
           file: app/build/outputs/apk/release/app-release.apk
 
-      - name: Slack 알림 (Firebase 배포 성공)
+      - name: Slack 알림 (빌드 성공)
         if: success()
-        uses: rtCamp/action-slack-notify@v2
+        uses: 8398a7/action-slack@v3
+        with:
+          status: success
+          fields: workflow,job,commit,repo,author,took,ref
+          author_name: GitHub Actions
+          text: "🚀 Firebase App Distribution 배포 성공! 브랜치: `${{ github.ref_name }}` 커밋: `${{ github.sha }}`"
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-          SLACK_CHANNEL: '#client-actions'
-          SLACK_MESSAGE: "🚀 Firebase App Distribution 배포 성공! 브랜치: `${{ github.ref_name }}` 커밋: `${{ github.sha }}`"
 
-      - name: Slack 알림 (Firebase 배포 실패)
+      - name: Slack 알림 (빌드 실패)
         if: failure()
-        uses: rtCamp/action-slack-notify@v2
+        uses: 8398a7/action-slack@v3
+        with:
+          status: failure
+          fields: workflow,job,commit,repo,author,took,ref
+          author_name: GitHub Actions
+          text: "🚨 Firebase App Distribution 배포 실패! 브랜치: `${{ github.ref_name }}` 커밋: `${{ github.sha }}`"
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-          SLACK_CHANNEL: '#client-actions'
-          SLACK_MESSAGE: "🚨 Firebase App Distribution 배포 실패! 브랜치: `${{ github.ref_name }}` 커밋: `${{ github.sha }}`"
-          SLACK_COLOR: 'danger'

--- a/.github/workflows/ace_internal_test.yml
+++ b/.github/workflows/ace_internal_test.yml
@@ -1,0 +1,96 @@
+# CD-GooglePlay-Internal.yml - Google Play Console 내부 테스트 배포 워크플로우
+name: Google Play Internal Test CD
+
+#on:
+#  push:
+#    branches:
+#      - main
+
+jobs:
+  google_play_internal:
+    name: Google Play Internal Test
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: 코드 체크아웃
+        uses: actions/checkout@v4
+
+      - name: JDK 17 설정
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+
+      - name: Gradle 캐시 설정
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+
+#      - name: local.properties 설정
+#        run: |
+#          echo "base.url=\"${{ secrets.BASE_URL }}\"" >> local.properties
+
+      - name: google-services.json 설정
+        # Firebase 서비스에 필요한 google-services.json 파일을 Secrets에서 가져옵니다.
+        run: |
+          echo "google-services.json 파일을 설정합니다..."
+          echo '${{ secrets.GOOGLE_SERVICES_JSON }}' > ./app/google-services.json
+          if [ -f ./app/google-services.json ]; then
+            echo "google-services.json이 ./app/google-services.json에 성공적으로 생성되었습니다."
+          else
+            echo "오류: ./app/google-services.json에서 google-services.json을 찾을 수 없습니다."
+            exit 1
+          fi
+        shell: bash
+
+      - name: 출시 서명 키 설정
+        # Android App Bundle 서명을 위한 키스토어 파일을 Base64로 인코딩된 Secrets에서 디코딩하여 생성합니다.
+        # SIGNING_KEY_BASE64는 GitHub Actions Secrets에 미리 설정되어 있어야 합니다.
+        run: |
+          echo "${{ secrets.SIGNING_KEY_BASE64 }}" | base64 --decode > android_signing_key.jks
+        # 키스토어 파일의 비밀번호, 별칭 등은 Secrets에 별도로 저장해야 합니다.
+
+      - name: gradlew 실행 권한 부여
+        run: chmod +x ./gradlew
+
+      - name: 릴리스 AAB 빌드 (Google Play 내부 테스트용)
+        # Google Play Console 배포를 위해 릴리스 AAB(Android App Bundle)를 빌드합니다.
+        run: ./gradlew bundleRelease
+        env:
+          # Gradle에 서명 정보를 환경 변수로 전달합니다.
+          ORG_GRADLE_PROJECT_signingStoreFile: android_signing_key.jks
+          ORG_GRADLE_PROJECT_signingKeyAlias: ${{ secrets.SIGNING_KEY_ALIAS }}
+          ORG_GRADLE_PROJECT_signingKeyPassword: ${{ secrets.SIGNING_KEY_PASSWORD }}
+          ORG_GRADLE_PROJECT_signingStorePassword: ${{ secrets.SIGNING_STORE_PASSWORD }}
+
+      - name: Google Play Console 내부 테스트 배포
+        # 빌드된 릴리스 AAB를 Google Play Console 내부 테스트 트랙으로 배포합니다.
+        # r0adkll/upload-google-play 액션을 사용합니다.
+        uses: r0adkll/upload-google-play@v1
+        with:
+          serviceAccountJson: ${{ secrets.GOOGLE_PLAY_SERVICE_ACCOUNT_KEY }} # Google Play 서비스 계정 JSON (Base64 인코딩된 내용)
+          packageName: your.package.name # 서비스명 확정 후 앱의 실제 패키지 이름으로 변경해야 합니다.
+          releaseFile: app/build/outputs/bundle/release/app-release.aab
+          track: internal
+
+      - name: Slack 알림 (Google Play 내부 테스트 성공)
+        if: success()
+        uses: rtCamp/action-slack-notify@v2
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          SLACK_CHANNEL: '#client-actions'
+          SLACK_MESSAGE: "🚀 Google Play 내부 테스트 배포 성공! 브랜치: `${{ github.ref_name }}` 커밋: `${{ github.sha }}`"
+
+      - name: Slack 알림 (Google Play 내부 테스트 실패)
+        if: failure()
+        uses: rtCamp/action-slack-notify@v2
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          SLACK_CHANNEL: '#client-actions'
+          SLACK_MESSAGE: "🚨 Google Play 내부 테스트 배포 실패! 브랜치: `${{ github.ref_name }}` 커밋: `${{ github.sha }}`"
+          SLACK_COLOR: 'danger'

--- a/.github/workflows/ace_internal_test.yml
+++ b/.github/workflows/ace_internal_test.yml
@@ -31,9 +31,9 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-gradle-
 
-#      - name: local.properties 설정
-#        run: |
-#          echo "base.url=\"${{ secrets.BASE_URL }}\"" >> local.properties
+      #      - name: local.properties 설정
+      #        run: |
+      #          echo "base.url=\"${{ secrets.BASE_URL }}\"" >> local.properties
 
       - name: google-services.json 설정
         # Firebase 서비스에 필요한 google-services.json 파일을 Secrets에서 가져옵니다.
@@ -78,19 +78,24 @@ jobs:
           releaseFile: app/build/outputs/bundle/release/app-release.aab
           track: internal
 
-      - name: Slack 알림 (Google Play 내부 테스트 성공)
+      - name: Slack 알림 (내부 테스트 배포 성공)
         if: success()
-        uses: rtCamp/action-slack-notify@v2
+        uses: 8398a7/action-slack@v3
+        with:
+          status: success
+          fields: workflow,job,commit,repo,author,took,ref
+          author_name: GitHub Actions
+          text: "🚀 Google Play 내부 테스트 배포 성공! 브랜치: `${{ github.ref_name }}` 커밋: `${{ github.sha }}`"
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-          SLACK_CHANNEL: '#client-actions'
-          SLACK_MESSAGE: "🚀 Google Play 내부 테스트 배포 성공! 브랜치: `${{ github.ref_name }}` 커밋: `${{ github.sha }}`"
 
-      - name: Slack 알림 (Google Play 내부 테스트 실패)
+      - name: Slack 알림 (내부 테스트 배포 실패)
         if: failure()
-        uses: rtCamp/action-slack-notify@v2
+        uses: 8398a7/action-slack@v3
+        with:
+          status: failure
+          fields: workflow,job,commit,repo,author,took,ref
+          author_name: GitHub Actions
+          text: "🚨 Google Play 내부 테스트 배포 실패! 브랜치: `${{ github.ref_name }}` 커밋: `${{ github.sha }}`"
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-          SLACK_CHANNEL: '#client-actions'
-          SLACK_MESSAGE: "🚨 Google Play 내부 테스트 배포 실패! 브랜치: `${{ github.ref_name }}` 커밋: `${{ github.sha }}`"
-          SLACK_COLOR: 'danger'

--- a/.github/workflows/ace_production.yml
+++ b/.github/workflows/ace_production.yml
@@ -1,0 +1,96 @@
+# CD-GooglePlay-Production.yml - Google Play Console 프로덕션 배포 워크플로우
+name: Google Play Production Release CD
+
+## 워크플로우 트리거 설정
+#on:
+#  push:
+#    tags:
+#      - 'v*' # 'v'로 시작하는 태그(예: v1.0.0)가 푸시되었을 때만 트리거
+
+jobs:
+  google_play_production:
+    name: Google Play Production Release
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: 코드 체크아웃
+        uses: actions/checkout@v4
+
+      - name: JDK 17 설정
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+
+      - name: Gradle 캐시 설정
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+
+      - name: local.properties 설정
+        run: |
+          echo "base.url=\"${{ secrets.BASE_URL }}\"" >> local.properties
+          echo "cloud.vision.api.key=\"${{ secrets.CLOUD_VISION_API_KEY }}\"" >> local.properties
+
+      - name: google-services.json 설정
+        # Firebase 서비스에 필요한 google-services.json 파일을 Secrets에서 가져옵니다.
+        run: |
+          echo "google-services.json 파일을 설정합니다..."
+          echo '${{ secrets.GOOGLE_SERVICES_JSON }}' > ./app/google-services.json
+          if [ -f ./app/google-services.json ]; then
+            echo "google-services.json이 ./app/google-services.json에 성공적으로 생성되었습니다."
+          else
+            echo "오류: ./app/google-services.json에서 google-services.json을 찾을 수 없습니다."
+            exit 1
+          fi
+        shell: bash
+
+      - name: 출시 서명 키 설정
+        # Android App Bundle 서명을 위한 키스토어 파일을 Base64로 인코딩된 Secrets에서 디코딩하여 생성합니다.
+        run: |
+          echo "${{ secrets.SIGNING_KEY_BASE64 }}" | base64 --decode > android_signing_key.jks
+
+      - name: gradlew 실행 권한 부여
+        run: chmod +x ./gradlew
+
+      - name: 릴리스 AAB 빌드 (Google Play 프로덕션용)
+        # Google Play Console 배포를 위해 릴리스 AAB를 빌드합니다.
+        run: ./gradlew bundleRelease
+        env:
+          # 서명 환경 변수
+          ORG_GRADLE_PROJECT_signingStoreFile: android_signing_key.jks
+          ORG_GRADLE_PROJECT_signingKeyAlias: ${{ secrets.SIGNING_KEY_ALIAS }}
+          ORG_GRADLE_PROJECT_signingKeyPassword: ${{ secrets.SIGNING_KEY_PASSWORD }}
+          ORG_GRADLE_PROJECT_signingStorePassword: ${{ secrets.SIGNING_STORE_PASSWORD }}
+
+      - name: Google Play Console 프로덕션 배포
+        # 빌드된 릴리스 AAB를 Google Play Console 프로덕션 트랙으로 배포합니다.
+        uses: r0adkll/upload-google-play@v1
+        with:
+          serviceAccountJson: ${{ secrets.GOOGLE_PLAY_SERVICE_ACCOUNT_KEY }}
+          packageName: your.package.name # 서비스명 확정 후 앱의 실제 패키지 이름으로 변경해야 합니다.
+          releaseFile: app/build/outputs/bundle/release/app-release.aab
+          track: production # 프로덕션 트랙으로 지정
+          status: completed # 출시 상태를 'completed'로 설정하여 즉시 출시되도록 합니다.
+
+      - name: Slack 알림 (Google Play 프로덕션 배포 성공)
+        if: success()
+        uses: rtCamp/action-slack-notify@v2
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          SLACK_CHANNEL: '#client-actions'
+          SLACK_MESSAGE: "🚀 Google Play 프로덕션 배포 성공! 태그: `${{ github.ref_name }}` 커밋: `${{ github.sha }}`"
+
+      - name: Slack 알림 (Google Play 프로덕션 배포 실패)
+        if: failure()
+        uses: rtCamp/action-slack-notify@v2
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          SLACK_CHANNEL: '#client-actions'
+          SLACK_MESSAGE: "🚨 Google Play 프로덕션 배포 실패! 태그: `${{ github.ref_name }}` 커밋: `${{ github.sha }}`"
+          SLACK_COLOR: 'danger'

--- a/.github/workflows/ace_production.yml
+++ b/.github/workflows/ace_production.yml
@@ -80,17 +80,22 @@ jobs:
 
       - name: Slack 알림 (Google Play 프로덕션 배포 성공)
         if: success()
-        uses: rtCamp/action-slack-notify@v2
+        uses: 8398a7/action-slack@v3
+        with:
+          status: success
+          fields: workflow,job,commit,repo,author,took,ref
+          author_name: GitHub Actions
+          text: "🚀 Google Play 프로덕션 배포 성공! 태그: `${{ github.ref_name }}` 커밋: `${{ github.sha }}`"
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-          SLACK_CHANNEL: '#client-actions'
-          SLACK_MESSAGE: "🚀 Google Play 프로덕션 배포 성공! 태그: `${{ github.ref_name }}` 커밋: `${{ github.sha }}`"
 
       - name: Slack 알림 (Google Play 프로덕션 배포 실패)
         if: failure()
-        uses: rtCamp/action-slack-notify@v2
+        uses: 8398a7/action-slack@v3
+        with:
+          status: failure
+          fields: workflow,job,commit,repo,author,took,ref
+          author_name: GitHub Actions
+          text: "🚨 Google Play 프로덕션 배포 실패! 태그: `${{ github.ref_name }}` 커밋: `${{ github.sha }}`"
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-          SLACK_CHANNEL: '#client-actions'
-          SLACK_MESSAGE: "🚨 Google Play 프로덕션 배포 실패! 태그: `${{ github.ref_name }}` 커밋: `${{ github.sha }}`"
-          SLACK_COLOR: 'danger'


### PR DESCRIPTION
- closed #1 

## 작업 내용

- github actions를 이용한 ci/cd 구축 

## 이건 꼭 봐주세요
- coderabbit 환경 설정 테스트 중 
  - 언어 변경이 안되고 있네요 ... ㅎㅎ 이건 좀 더 알아보고있을게요 ! -> 한글 설정 완료했습니다. 
- 기존 계획대로 CD 파일을 다음과 같이 작성했었습니다
  - firebase_distribution.yml
  - internal_test.yml
  - production.yml
- 위의 cd 파일을 위해서는 firebase 프로젝트 등록이 필요한데, 패키지명은 변경할 수 없어 서비스명이 확정되면 패키지 수정 후, 필요한 등록 + 키 발급을 진행 후 on (트리거 관련 코드) 를 주석 해제하도록 하겠습니다. 또, 그때 kmp/cmp 관련해서 수정도해볼게요 

## Summary by CodeRabbit

* **Chores**
  * 코드 소유자 지정 파일이 추가되어 모든 파일에 대해 자동으로 리뷰어가 할당됩니다.
  * GitHub Actions 워크플로우가 추가되어 PR CI 빌드, Firebase App Distribution 배포, Google Play 내부 테스트 및 프로덕션 배포가 자동화됩니다.
  * 빌드 및 배포 성공/실패 시 Slack 알림이 전송됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->