### PR TITLE
[feature/#38][feature/#49] 다시 대화하기 기능 구현 및 폴드 기기 대응

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,9 @@ render.experimental.xml
 # Google Services (e.g. APIs or Firebase)
 google-services.json
 
+# Credential files
+emotia-credential.json
+
 # Android Profiling
 *.hprof
 

--- a/composeApp/src/androidMain/res/drawable/ic_splash_screen.xml
+++ b/composeApp/src/androidMain/res/drawable/ic_splash_screen.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <layer-list xmlns:android="http://schemas.android.com/apk/res/android">
-    <item android:drawable="@android:color/white" />
+    <item android:drawable="@android:color/black" />
 
     <item android:gravity="center">
         <bitmap

--- a/composeApp/src/androidMain/res/values/themes.xml
+++ b/composeApp/src/androidMain/res/values/themes.xml
@@ -2,7 +2,7 @@
 <resources>
 
     <style name="Theme.Emotia.SplashScreen" parent="Theme.SplashScreen">
-        <item name="windowSplashScreenBackground">@android:color/white</item>
+        <item name="windowSplashScreenBackground">@android:color/black</item>
         <item name="windowSplashScreenAnimatedIcon">@drawable/ic_splash_screen</item>
         <item name="postSplashScreenTheme">@style/Theme.Emotia.Main</item>
     </style>

--- a/feature/chatting/src/commonMain/kotlin/com/nexters/emotia/feature/chatting/ChattingScreen.kt
+++ b/feature/chatting/src/commonMain/kotlin/com/nexters/emotia/feature/chatting/ChattingScreen.kt
@@ -115,7 +115,7 @@ fun ChattingScreen(
     val animatedRadius by animateFloatAsState(
         targetValue = when (animationPhase) {
             0 -> 2000f // 정지 상태
-            1 -> fairyCardSize // 1단계: 축소
+            1 -> fairyCardSize * 0.7f // 1단계: 축소 (70% 크기로 더 작게)
             2 -> 0f // 2단계: 완전 차단
             else -> 2000f
         },

--- a/feature/chatting/src/commonMain/kotlin/com/nexters/emotia/feature/chatting/ChattingScreen.kt
+++ b/feature/chatting/src/commonMain/kotlin/com/nexters/emotia/feature/chatting/ChattingScreen.kt
@@ -434,7 +434,7 @@ private fun FairySelectionScreen(
             ),
             onConfirmClick = onSpotlightAnimationStart,
             onRetryClick = {
-                // TODO: 다시 대화하기 구현
+                viewModel.handleIntent(ChattingIntent.RestartChat)
             }
         )
     }

--- a/feature/chatting/src/commonMain/kotlin/com/nexters/emotia/feature/chatting/ChattingViewModel.kt
+++ b/feature/chatting/src/commonMain/kotlin/com/nexters/emotia/feature/chatting/ChattingViewModel.kt
@@ -43,6 +43,7 @@ class ChattingViewModel(
             is ChattingIntent.ClearError -> clearError()
             is ChattingIntent.LoadFairies -> loadFairies()
             is ChattingIntent.SelectFairy -> selectFairy(intent.index)
+            is ChattingIntent.RestartChat -> restartChat()
         }
     }
 
@@ -181,6 +182,11 @@ class ChattingViewModel(
 
     private fun selectFairy(index: Int) = intent {
         reduce { state.copy(selectedFairyIndex = index) }
+    }
+
+    private fun restartChat() = intent {
+        reduce { ChattingState() }
+        createChatRoom()
     }
 
     private fun getUserMessageCount(messages: PersistentList<ChatMessage>): Int {

--- a/feature/chatting/src/commonMain/kotlin/com/nexters/emotia/feature/chatting/contract/ChattingIntent.kt
+++ b/feature/chatting/src/commonMain/kotlin/com/nexters/emotia/feature/chatting/contract/ChattingIntent.kt
@@ -11,4 +11,5 @@ sealed interface ChattingIntent {
     data object ClearError : ChattingIntent
     data object LoadFairies : ChattingIntent
     data class SelectFairy(val index: Int) : ChattingIntent
+    data object RestartChat : ChattingIntent
 }

--- a/feature/result/src/commonMain/kotlin/com/nexters/emotia/feature/result/fairy/FairyScreen.kt
+++ b/feature/result/src/commonMain/kotlin/com/nexters/emotia/feature/result/fairy/FairyScreen.kt
@@ -18,6 +18,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -41,6 +42,7 @@ import coil3.compose.SubcomposeAsyncImage
 import coil3.request.ImageRequest
 import coil3.request.crossfade
 import com.nexters.emotia.core.designsystem.component.TypingAnimatedSpeechBubble
+import com.nexters.emotia.core.designsystem.theme.EmotiaTheme.colors
 import com.nexters.emotia.feature.result.fairy.contract.FairyIntent
 import com.nexters.emotia.feature.result.fairy.contract.FairySideEffect
 import emotia.core.designsystem.generated.resources.Res
@@ -98,6 +100,7 @@ fun FairyScreen(
     Box(
         modifier = modifier
             .fillMaxSize()
+            .background(colors.black)
             .navigationBarsPadding()
             .clickable(
                 interactionSource = remember { MutableInteractionSource() },
@@ -112,46 +115,74 @@ fun FairyScreen(
                 }
             }
     ) {
-        Column(modifier = Modifier.fillMaxSize()) {
-            Box(modifier = Modifier.fillMaxWidth()) {
-                Image(
-                    painter = painterResource(Res.drawable.img_letter_background),
-                    contentDescription = "Background Image",
-                    modifier = Modifier.fillMaxWidth(),
-                    contentScale = ContentScale.FillWidth
-                )
+        Box(
+            modifier = Modifier.fillMaxSize(),
+            contentAlignment = Alignment.TopCenter
+        ) {
+            Column(
+                modifier = Modifier
+                    .widthIn(max = 500.dp)
+                    .fillMaxWidth()
+            ) {
+                Box(modifier = Modifier.fillMaxWidth()) {
+                    Image(
+                        painter = painterResource(Res.drawable.img_letter_background),
+                        contentDescription = "Background Image",
+                        modifier = Modifier.fillMaxWidth(),
+                        contentScale = ContentScale.FillWidth
+                    )
 
-                SubcomposeAsyncImage(
-                    model = ImageRequest.Builder(LocalPlatformContext.current)
-                        .data(fairyImage)
-                        .crossfade(true)
-                        .build(),
-                    contentDescription = "$fairyImage image",
-                    contentScale = ContentScale.Inside,
+                    SubcomposeAsyncImage(
+                        model = ImageRequest.Builder(LocalPlatformContext.current)
+                            .data(fairyImage)
+                            .crossfade(true)
+                            .build(),
+                        contentDescription = "$fairyImage image",
+                        contentScale = ContentScale.Inside,
+                        modifier = Modifier
+                            .size(108.dp)
+                            .align(Alignment.BottomCenter)
+                            .offset(y = (-49).dp)
+                            .clip(RoundedCornerShape(16.dp)),
+                        error = {
+                            // TODO : 에러 이미지 처리
+                        },
+                    )
+                }
+
+                Box(
                     modifier = Modifier
-                        .size(108.dp)
-                        .align(Alignment.BottomCenter)
-                        .offset(y = (-49).dp)
-                        .clip(RoundedCornerShape(16.dp)),
-                    error = {
-                        // TODO : 에러 이미지 처리
-                    },
+                        .weight(1f)
+                        .fillMaxWidth()
+                        .background(
+                            brush = Brush.verticalGradient(
+                                colors = listOf(
+                                    Color(0xFF171E2D),
+                                    Color(0xFF1A1A1B)
+                                )
+                            )
+                        )
                 )
             }
 
-            Box(
-                modifier = Modifier
-                    .weight(1f)
-                    .fillMaxWidth()
-                    .background(
-                        brush = Brush.verticalGradient(
-                            colors = listOf(
-                                Color(0xFF171E2D),
-                                Color(0xFF1A1A1B)
-                            )
+            if (stepTexts != null && animatedRadius >= 1800f) {
+                Box(
+                    modifier = Modifier
+                        .widthIn(max = 500.dp)
+                        .align(Alignment.BottomCenter)
+                ) {
+                    AnimatedVisibility(
+                        visible = true,
+                        enter = fadeIn(tween(300)),
+                        exit = fadeOut(tween(300))
+                    ) {
+                        TypingAnimatedSpeechBubble(
+                            fullText = stepTexts,
+                            useAlternativeBackground = false
                         )
-                    )
-            )
+                    }
+                }
+            }
         }
 
         if (animatedRadius < 1800f) {
@@ -181,19 +212,6 @@ fun FairyScreen(
             }
         }
 
-        if (stepTexts != null && animatedRadius >= 1800f) {
-            AnimatedVisibility(
-                visible = true,
-                enter = fadeIn(tween(300)),
-                exit = fadeOut(tween(300)),
-                modifier = Modifier.align(Alignment.BottomCenter)
-            ) {
-                TypingAnimatedSpeechBubble(
-                    fullText = stepTexts,
-                    useAlternativeBackground = false
-                )
-            }
-        }
     }
 }
 

--- a/feature/result/src/commonMain/kotlin/com/nexters/emotia/feature/result/letter/LetterScreen.kt
+++ b/feature/result/src/commonMain/kotlin/com/nexters/emotia/feature/result/letter/LetterScreen.kt
@@ -135,102 +135,102 @@ fun LetterScreen(
                 .verticalScroll(scrollState),
             horizontalAlignment = Alignment.CenterHorizontally
         ) {
-        Box {
-            Image(
-                painter = painterResource(Res.drawable.img_letter_background),
-                contentDescription = "Background Image",
-                modifier = Modifier.fillMaxWidth(),
-                contentScale = ContentScale.FillWidth
-            )
+            Box {
+                Image(
+                    painter = painterResource(Res.drawable.img_letter_background),
+                    contentDescription = "Background Image",
+                    modifier = Modifier.fillMaxWidth(),
+                    contentScale = ContentScale.FillWidth
+                )
 
-            SubcomposeAsyncImage(
-                model = ImageRequest.Builder(LocalPlatformContext.current)
-                    .data(fairyImage)
-                    .crossfade(true)
-                    .build(),
-                contentDescription = "$fairyImage image",
-                contentScale = ContentScale.Inside,
-                modifier = Modifier
-                    .size(108.dp)
-                    .align(Alignment.BottomCenter)
-                    .offset(y = (-49).dp)
-                    .clip(RoundedCornerShape(16.dp)),
-                error = {
-                    // TODO : 에러 이미지 처리
-                },
-            )
-        }
+                SubcomposeAsyncImage(
+                    model = ImageRequest.Builder(LocalPlatformContext.current)
+                        .data(fairyImage)
+                        .crossfade(true)
+                        .build(),
+                    contentDescription = "$fairyImage image",
+                    contentScale = ContentScale.Inside,
+                    modifier = Modifier
+                        .size(108.dp)
+                        .align(Alignment.BottomCenter)
+                        .offset(y = (-49).dp)
+                        .clip(RoundedCornerShape(16.dp)),
+                    error = {
+                        // TODO : 에러 이미지 처리
+                    },
+                )
+            }
 
-        Column(
-            modifier = Modifier
-                .let { modifier ->
-                    if (isKeyboardVisible) {
-                        modifier.fillMaxWidth()
-                    } else {
-                        modifier.weight(1f).fillMaxWidth()
-                    }
-                }
-                .background(
-                    brush = Brush.verticalGradient(
-                        colors = listOf(
-                            Color(0xFF171E2D),
-                            Color(0xFF1A1A1B)
-                        )
-                    )
-                ),
-            horizontalAlignment = Alignment.CenterHorizontally
-        ) {
-            Spacer(modifier = Modifier.height(28.dp))
-
-            EmotiaMultiLineTextField(
-                value = uiState.contents,
-                onValueChange = { viewModel.handleIntent(LetterIntent.UpdateContents(it)) },
-                placeholder = "${fairyName}에게 위로의 말을 건네보자.",
+            Column(
                 modifier = Modifier
                     .let { modifier ->
                         if (isKeyboardVisible) {
-                            modifier.heightIn(min = 160.dp)
+                            modifier.fillMaxWidth()
                         } else {
-                            modifier.weight(1f)
+                            modifier.weight(1f).fillMaxWidth()
                         }
                     }
-                    .fillMaxWidth()
-                    .padding(horizontal = 24.dp)
-            )
+                    .background(
+                        brush = Brush.verticalGradient(
+                            colors = listOf(
+                                Color(0xFF171E2D),
+                                Color(0xFF1A1A1B)
+                            )
+                        )
+                    ),
+                horizontalAlignment = Alignment.CenterHorizontally
+            ) {
+                Spacer(modifier = Modifier.height(28.dp))
 
-            Spacer(modifier = Modifier.height(32.dp))
+                EmotiaMultiLineTextField(
+                    value = uiState.contents,
+                    onValueChange = { viewModel.handleIntent(LetterIntent.UpdateContents(it)) },
+                    placeholder = "${fairyName}에게 위로의 말을 건네보자.",
+                    modifier = Modifier
+                        .let { modifier ->
+                            if (isKeyboardVisible) {
+                                modifier.heightIn(min = 160.dp)
+                            } else {
+                                modifier.weight(1f)
+                            }
+                        }
+                        .fillMaxWidth()
+                        .padding(horizontal = 24.dp)
+                )
 
-            EmotiaButton(
-                text = "위로 건네기",
-                onClick = {
-                    viewModel.handleIntent(LetterIntent.SendLetter)
-                },
-                enabled = uiState.contents.isNotBlank() && !uiState.isLoading,
-                modifier = Modifier.padding(horizontal = 24.dp)
-            )
+                Spacer(modifier = Modifier.height(32.dp))
 
-            Spacer(modifier = Modifier.height(16.dp))
-
-            Text(
-                text = "다시 대화하기",
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .clickable {
-                        onNavigateToChatting()
+                EmotiaButton(
+                    text = "위로 건네기",
+                    onClick = {
+                        viewModel.handleIntent(LetterIntent.SendLetter)
                     },
-                style = typography.emotia14M.copy(
-                    color = colors.lightGray,
-                    textDecoration = TextDecoration.Underline
-                ),
-                textAlign = TextAlign.Center
-            )
+                    enabled = uiState.contents.isNotBlank() && !uiState.isLoading,
+                    modifier = Modifier.padding(horizontal = 24.dp)
+                )
 
-            Spacer(modifier = Modifier.height(24.dp))
+                Spacer(modifier = Modifier.height(16.dp))
 
-            if (isKeyboardVisible) {
-                Spacer(modifier = Modifier.height(210.dp))
+                Text(
+                    text = "다시 대화하기",
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .clickable {
+                            onNavigateToChatting()
+                        },
+                    style = typography.emotia14M.copy(
+                        color = colors.lightGray,
+                        textDecoration = TextDecoration.Underline
+                    ),
+                    textAlign = TextAlign.Center
+                )
+
+                Spacer(modifier = Modifier.height(24.dp))
+
+                if (isKeyboardVisible) {
+                    Spacer(modifier = Modifier.height(210.dp))
+                }
             }
-        }
 
             // TODO : 로딩이 빨라서 보류. 다른 정책 필요
 //            // 로딩 오버레이

--- a/feature/result/src/commonMain/kotlin/com/nexters/emotia/feature/result/letter/LetterScreen.kt
+++ b/feature/result/src/commonMain/kotlin/com/nexters/emotia/feature/result/letter/LetterScreen.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -18,6 +19,7 @@ import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
@@ -121,6 +123,7 @@ fun LetterScreen(
     Box(
         modifier = modifier
             .fillMaxSize()
+            .background(colors.black)
             .clickable(
                 interactionSource = remember { MutableInteractionSource() },
                 indication = null
@@ -128,13 +131,18 @@ fun LetterScreen(
                 focusManager.clearFocus()
             }
     ) {
-        Column(
-            modifier = Modifier
-                .fillMaxSize()
-                .navigationBarsPadding()
-                .verticalScroll(scrollState),
-            horizontalAlignment = Alignment.CenterHorizontally
+        Box(
+            modifier = Modifier.fillMaxSize(),
+            contentAlignment = Alignment.TopCenter
         ) {
+            Column(
+                modifier = Modifier
+                    .widthIn(max = 500.dp)
+                    .fillMaxSize()
+                    .navigationBarsPadding()
+                    .verticalScroll(scrollState),
+                horizontalAlignment = Alignment.CenterHorizontally
+            ) {
             Box {
                 Image(
                     painter = painterResource(Res.drawable.img_letter_background),
@@ -247,6 +255,7 @@ fun LetterScreen(
 //                    )
 //                }
 //            }
+        }
         }
     }
 }


### PR DESCRIPTION

- closed #38 
- closed #49 

## 작업 내용

- 다시 대화하기 기능 구현했습니다.
- 컨텐츠들이 최대로 늘어날 수 있는 너비를 지정해서 폴드 기기들에서 잘 보이게 조정했습니다. 500이 딱 적당한 것 같더라구요
- LetterScreen에 키보드 올라왔을때 하단에 강제 패딩을 주기 싫어서 채팅 화면에 적용한 것처럼 하려다 제약을 발견했습니다. 채팅 화면에서는 키보드가 올라왔을 때 배경이 어느정도 가려지는데, 요정등장화면/편지보내기화면 에서는 배경 이미지 하단 부에 요정 이미지가 같이 있어서 텍스트 필드가 키보드 위로 올라왔을 때 얘네들이 가려지는게 어색하더라구요.. 텍스트 필드에 elevation이 있는 느낌? 이라 이거는 논의가 좀 필요할 것 같아요.
- 두 화면에서만 최대너비를 지정하는게 폴드 유저들이 이상하게 여기지는 않을까 궁금하긴 하네요. 흠.. 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - 대화 재시작(다시 대화하기) 기능을 추가해 재시도 흐름을 지원합니다.

- Style
  - 스플래시 화면 배경을 검정으로 변경해 일관된 다크 톤을 제공합니다.
  - 결과(요정)·편지 화면 레이아웃을 개선: 전체 검정 배경, 중앙 정렬 및 최대 폭 제한, 말풍선 표시 타이밍 최적화, 이미지 표시 품질(둥근 모서리·오류 처리) 향상, 스크롤/키보드 대응 및 그라디언트 영역 정리.

- Chores
  - 민감한 자격 증명 파일을 버전 관리에서 제외했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->